### PR TITLE
Feature/api key

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,10 @@
+provider "mgc" {
+  region = var.mgc_region
+  api_key = var.mgc_api_key
+  object_storage = {
+    key_pair = {
+      key_id = var.mgc_obj_key_id
+      key_secret = var.mgc_obj_key_secret
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,23 @@ variable "timer_duration" {
   type        = string
   default     = "15m"
 }
+
+variable "mgc_api_key" {
+  type = string
+  description = "Chave da Magalu Cloud"
+}
+
+variable "mgc_obj_key_id" {
+  type = string
+  description = "ID da Chave do Object Storage"
+}
+
+variable "mgc_obj_key_secret" {
+  type = string
+  description = "Secret da Chave do Object Storage"
+}
+
+variable "mgc_region" {
+  type = string
+  description = "Região da Magalu Cloud"
+}


### PR DESCRIPTION
Adiciona configuração do provider mgc no arquivo providers.tf 

Adiciona variaveis de ambiente seguindo a documentação https://docs.magalu.cloud/docs/general/env-variables

Para realização do teste é necessário adicionar no host as variaveis de ambiente com seus respectivos valores

TF_VAR_mgc_api_key=
TF_VAR_mgc_obj_key_id=
TF_VAR_mgc_obj_key_secret=
TF_VAR_mgc_region=

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration for the "mgc" provider, enhancing cloud integration in Terraform.
	- Added new variables to customize and secure the connection to the Magalu Cloud service.

- **Improvements**
	- Improved modularity and configurability of infrastructure code, enabling dynamic settings for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->