### PR TITLE
Feature/docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.20.0
+
+# Definir o diretório de trabalho
+WORKDIR /app
+
+# Atualiza os índices de pacote do Alpine e instala as versões específicas
+# dos pacotes curl, wget e tar, sem guardar o cache dos pacotes para reduzir o tamanho.
+RUN apk update && \
+    apk add --no-cache \
+    bash=5.2.26-r0 \
+    curl=8.9.0-r0 \
+    wget=1.24.5-r0 \
+    tar=1.35-r2
+
+# Definir a versão do MGC_CLI
+ARG MGC_VERSION=0.23.0
+# Baixa o arquivo tar.gz do mgccli do GitHub de forma silenciosa, extrai o conteúdo,
+# move o executável para /usr/local/bin, dá permissão de execução e remove os arquivos temporários.
+RUN wget https://github.com/MagaluCloud/mgccli/releases/download/v${MGC_VERSION}/mgccli_${MGC_VERSION}_linux_amd64.tar.gz --quiet && \
+    tar -xzf mgccli_${MGC_VERSION}_linux_amd64.tar.gz -C /tmp && \
+    mv /tmp/mgc /usr/local/bin/mgc && \
+    chmod +x /usr/local/bin/mgc && \
+    rm -rf /tmp/*
+
+# Definir a versão do Terraform
+ARG TERRAFORM_VERSION=1.9.4
+# Baixa o binário do Terraform e o instala em /usr/local/bin
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip --quiet && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/terraform && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+# Cria um usuário chamado 'non-root-user' com UID 1001 sem criar um diretório home padrão.
+RUN adduser -D -u 1001 non-root-user
+
+# O container escutará na porta 8095.
+EXPOSE 8095
+
+# O container será executado como o usuário 'non-root-user'.
+USER non-root-user
+
+# Define o diretório de trabalho para /app.
+WORKDIR /app
+
+# Define o comando padrão e o shell para execução.
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+
+
+services:
+  mgcli:
+    container_name: mgcli
+    image: registry-local/mgcli:0.0.1
+    build: 
+      context: .
+      dockerfile: ./Dockerfile
+    tty: true
+    ports:
+      - "8095:8095"
+    volumes:
+      - ./:/app
+    environment: 
+      - TF_VAR_mgc_api_key= #https://id.magalu.com/basic-information
+      - TF_VAR_mgc_obj_key_id=
+      - TF_VAR_mgc_obj_key_secret=
+      - TF_VAR_mgc_region=

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,10 @@
+provider "mgc" {
+  region = var.mgc_region
+  api_key = var.mgc_api_key
+  object_storage = {
+    key_pair = {
+      key_id = var.mgc_obj_key_id
+      key_secret = var.mgc_obj_key_secret
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,23 @@ variable "timer_duration" {
   type        = string
   default     = "15m"
 }
+
+variable "mgc_api_key" {
+  type = string
+  description = "Chave da Magalu Cloud"
+}
+
+variable "mgc_obj_key_id" {
+  type = string
+  description = "ID da Chave do Object Storage"
+}
+
+variable "mgc_obj_key_secret" {
+  type = string
+  description = "Secret da Chave do Object Storage"
+}
+
+variable "mgc_region" {
+  type = string
+  description = "Região da Magalu Cloud"
+}


### PR DESCRIPTION
Adiciona docker compose e dockerfile com uma configuração basica de terraform e mgcli para uso em um ambiente isolado

O docker-compose.yaml precisa de algumas variaveis de api-keys que estão disponiveis em https://id.magalu.com/basic-information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `mgcli` service in the docker-compose setup for enhanced functionality.
	- Added support for the `mgc` provider in Terraform, allowing for secure configurations and management.
	- Introduced several new variables for the Magalu Cloud configuration, enabling more customizable setups.

- **Chores**
	- Set up a lightweight Docker container environment optimized for applications using `mgccli` and `Terraform`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->